### PR TITLE
Look for config under the riemann section

### DIFF
--- a/src/riemann.js
+++ b/src/riemann.js
@@ -9,7 +9,7 @@ export default class Riemann {
    * transport, flush, packet
    */
   constructor(startupTime, config, emitter) {
-    this.config = config;
+    this.config = config.riemann;
     this.client = riemann.createClient({
       host: this.config.host,
       port: this.config.port


### PR DESCRIPTION
In 89305920 it was changed to look for the options (host, port...) at
the top level.  I can't tell if that was intentional or not and am submitting this under the assumption that it was not.  